### PR TITLE
Fix isolation mode crash where extension has no icons

### DIFF
--- a/public/isolation.js
+++ b/public/isolation.js
@@ -1,7 +1,7 @@
 import { disableExtensions, enableExtensions, updateIconState, getExtensionStateById} from "./utils/functions.js";
 
 // Type definitions.
-/** 
+/**
  * @typedef {object} TExtension
  * @property {string} description
  * @property {boolean} enabled
@@ -24,11 +24,10 @@ import { disableExtensions, enableExtensions, updateIconState, getExtensionState
  * @property {string} version
  */
 
-
 /**
-   * 
+   *
    * @param {TExtension[]}
-   * @param {number} step 
+   * @param {number} step
    * @returns {TExtension}
 */
 
@@ -43,7 +42,7 @@ async function isolationMode(extensionList, step=0) {
   // Split the extensions into two halves.
   const half1 = extensionList.slice(0, halfIndex);
   const half2 = extensionList.slice(halfIndex);
-  
+
   // Retreiving the bigger and smaller sizes for less steps to occur during isolation.
   const [biggerHalf, smallerHalf] = [half1, half2].sort((a, b) => b.length - a.length)
   console.log("---------------- All Extensions in this step. ---------------")
@@ -52,8 +51,8 @@ async function isolationMode(extensionList, step=0) {
   console.log(getExtensionNames(biggerHalf))
   console.log("----------------- SMALLER HALF -------------------")
   console.log(getExtensionNames(smallerHalf))
-  
-  
+
+
   // Isolate and enable only the biggerHalf of the extension list.
   enableExtensions(biggerHalf)
   disableExtensions(smallerHalf)
@@ -95,7 +94,7 @@ async function getUserFeedback(firstHalf) {
     extensionDiv.style.display = "flex"
     extensionDiv.style.gap = "0.2em"
     const iconImg = document.createElement('img');
-    iconImg.src = extension?.icons[0]?.url || "./images/chrome-32.png";
+    iconImg.src = extension?.icons?.[0]?.url || "./images/chrome-32.png";
     iconImg.alt = 'Extension Icon';
 
     iconImg.style.width = "25px";
@@ -180,7 +179,7 @@ isolationBtn.addEventListener("click", async () => {
     </div>`
 
     isolationBtn.style.display = "block"
-    
+
     confirmYes.style.display = "none"
     confirmNo.style.display = "none"
 


### PR DESCRIPTION
I encountered a bug when going into isolation mode. I've used your extension before and had no issues so I was confused.

I thought maybe an update introduced a bug, but I decided to investigate.

The issue is actually my Chrome extension, crashing yours trying to go into isolation mode.  Seems my extension doesn't have any `icons` (I thought it did but that's a different issue), and when it hits [this line](https://github.com/ItzBlinkzy/disable-all-extensions/blob/master/public/isolation.js#L98) you get an error.

```
isolation.js:98 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
    at isolation.js:98:35
    at Array.forEach (<anonymous>)
    at getUserFeedback (isolation.js:91:13)
    at isolationMode (isolation.js:60:26)
    at HTMLButtonElement.<anonymous> (isolation.js:164:26)
```

I changed the code to console log the extension name and icons.

```
console.log(extension.name, extension?.icons)
```

and it showed my extension had no icons

![CleanShot 2024-11-16 at 18 22 16@2x](https://github.com/user-attachments/assets/4040a5ac-6b7b-4c6e-9f9d-763383c94413)

How to reproduce:
- Install [this extension](https://chromewebstore.google.com/detail/tab-group-helper/llhkcebnebfiaamifhbpehjompplpnae?hl=en)
- In Disable All Extensions, go to Isolation Mode
- Click Start Isolation Mode

Expected Result:
- A sublist of extensions enabled is displayed
- Clicking Yes or No has an action

![CleanShot 2024-11-16 at 18 34 25@2x](https://github.com/user-attachments/assets/a7c4f2f3-7e46-41a0-816f-3e4721cac251)

Actual Result:
- The sublist is empty
- Clicking Yes or No does nothing

![CleanShot 2024-11-16 at 18 29 47@2x](https://github.com/user-attachments/assets/c605cd4d-4769-40ba-98ca-395aa038efa8)

I think I should fix my extension to have proper icons, but figured there's a possibility of a different extension having the same issue and a user thinking your extension doesn't work.

You'll notice my PR contains some non-functional changes that get rid of trailing whitespace so I hope that's fine, my IDE will fight me to keep removing them.  The only real change is [this](https://github.com/ItzBlinkzy/disable-all-extensions/compare/master...mikedidomizio:disable-all-extensions:fix-extension-with-no-icons#diff-2deca54ec5a7b8799a4dc7371d39ad705347842b4ddeab5534ebb5fe39f38f0bR97).

Thanks and by the way, great extension.
 